### PR TITLE
Add MIT license to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "repository": "satsukitv/twitter-block-chain",
   "version": "0.1",
   "main": "lib/main.js",
+  "license": "MIT",
   "icon": "data/icon32.png",
   "icon64": "data/icon64.png",
   "devDependencies": {


### PR DESCRIPTION
package.json contains no license property and NPM gives a warning. I think this may be intentional as the LICENSE indicates the previous code is under MIT and the new code is under CC0. IANAL but, as I understand copyright, the license the end-user receives for the project should probably be MIT. The reason I say that is, if one wanted to comply with the license to a T, you'd need to comply with the MIT requirements. Therefore, I think the package.json should have MIT.

There may be another way to look at this but this seems like the most cautious.
